### PR TITLE
Validate dedupe keys in csv_clean_normalize

### DIFF
--- a/scripts/python/data_quality/csv_clean_normalize.py
+++ b/scripts/python/data_quality/csv_clean_normalize.py
@@ -84,6 +84,14 @@ def main() -> int:
 
     date_columns = {normalize_header(col) for col in args.date_columns}
     dedupe_keys = [normalize_header(col) for col in args.dedupe_keys]
+    if args.drop_duplicates:
+        missing_dedupe_keys = [col for col in dedupe_keys if col not in normalized_headers]
+        if missing_dedupe_keys:
+            raise ValueError(
+                "Invalid --dedupe-keys value(s): "
+                f"{', '.join(missing_dedupe_keys)}. "
+                f"Available columns: {', '.join(normalized_headers)}"
+            )
 
     cleaned_rows = []
     seen = set()


### PR DESCRIPTION
## What changed
- Added validation for `--dedupe-keys` before duplicate-removal runs.
- `csv_clean_normalize.py` now raises a clear `ValueError` when a requested dedupe key does not exist in normalized headers.

## Why
An invalid dedupe key previously defaulted to empty values for every row, which silently collapsed output to one row when `--drop-duplicates` was enabled.

## Validation
- `python3 scripts/python/data_quality/csv_clean_normalize.py --input data/sample/student_records_source.csv --output /tmp/student_records_clean_valid.csv --drop-duplicates`
- `python3 scripts/python/data_quality/csv_clean_normalize.py --input data/sample/student_records_source.csv --output /tmp/student_records_clean_badkey.csv --drop-duplicates --dedupe-keys no_such_key` (fails fast as expected)

Fixes #1
