### PR TITLE
Validate threshold bounds in fuzzy_match_students CLI

### DIFF
--- a/scripts/python/reconciliation/fuzzy_match_students.py
+++ b/scripts/python/reconciliation/fuzzy_match_students.py
@@ -152,13 +152,16 @@ def parse_args() -> argparse.Namespace:
         "--threshold",
         type=float,
         default=0.86,
-        help="Minimum fuzzy score accepted as a match",
+        help="Minimum fuzzy score accepted as a match (0.0 to 1.0)",
     )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+
+    if not 0.0 <= args.threshold <= 1.0:
+        raise ValueError(f"--threshold must be between 0.0 and 1.0 inclusive (received: {args.threshold})")
 
     source_path = Path(args.source)
     target_path = Path(args.target)


### PR DESCRIPTION
## Summary
- validate `--threshold` bounds in `fuzzy_match_students.py`
- fail fast when values are outside the valid similarity range
- clarify help text to show the accepted range

## Validation
- `python3 scripts/python/reconciliation/fuzzy_match_students.py --source data/sample/student_records_source.csv --target data/sample/student_records_target.csv --output /tmp/fuzzy_valid.csv --summary /tmp/fuzzy_valid.json --threshold 0.86`
- `python3 scripts/python/reconciliation/fuzzy_match_students.py --source data/sample/student_records_source.csv --target data/sample/student_records_target.csv --output /tmp/fuzzy_invalid_low.csv --summary /tmp/fuzzy_invalid_low.json --threshold -0.5` (now fails fast)
- `python3 scripts/python/reconciliation/fuzzy_match_students.py --source data/sample/student_records_source.csv --target data/sample/student_records_target.csv --output /tmp/fuzzy_invalid_high.csv --summary /tmp/fuzzy_invalid_high.json --threshold 1.5` (now fails fast)

Closes #3
