### PR TITLE
Add early file validation to reconcile_students.py

### DIFF
--- a/scripts/python/reconciliation/reconcile_students.py
+++ b/scripts/python/reconciliation/reconcile_students.py
@@ -67,6 +67,11 @@ def main() -> int:
     output_path = Path(args.output)
     summary_path = Path(args.summary)
 
+    if not source_path.exists():
+        raise FileNotFoundError(f"Source CSV not found: {source_path}")
+    if not target_path.exists():
+        raise FileNotFoundError(f"Target CSV not found: {target_path}")
+
     source_rows = read_rows(source_path)
     target_rows = read_rows(target_path)
 


### PR DESCRIPTION
## What changed
- [x] Focused fix: Add missing file existence validation for `--source` and `--target` paths.
- [ ] Tests/validation updates
- [ ] Docs/readme update (if needed)

## Why
Script used to fail late in the execution flow when `csv.DictReader` tried to open a missing file. Adding early `Path.exists()` checks ensures the script fails fast with a clear `FileNotFoundError` before allocating memory or processing any data.

## Validation
- [x] Local run output attached (fails fast with `FileNotFoundError: Source CSV not found` as expected)
- [x] No regressions observed (valid paths still run correctly)

## Links
- Issue: #5
